### PR TITLE
README update, Redis deployment simplification and add Beans and Autowiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,13 @@ Your local cluster will be laid out as follows:
 
 ### 2. Dapr Dashboard & Components
 
-This will open the [Dapr dashboard](/docs/dapr-dashboard.png) in your default browser. This assumes you installed [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) in your local machine. You can validate that the setup finished successfully by navigating to <http://localhost:9000>.
+This will open the [Dapr dashboard](/docs/dapr-dashboard.png) in your default browser. This assumes you installed [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) in your local machine. 
 
 ```bash
 make dapr-dashboard
 ```
+
+You can validate that the setup of the dashboard finished successfully by navigating to <http://localhost:9000>.
 
 To verify the installation of pub/sub broker and other components:
 
@@ -226,6 +228,10 @@ make port-forward-local
 ```
 
 While this command is running, you can access the service at <http://localhost:8080>.
+
+```bash
+set PUBLIC_API_SERVICE=http://localhost:8080
+```
 
 First, you need to create a new account for a user:
 

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ make port-forward-local
 While this command is running, you can access the service at <http://localhost:8080>.
 
 ```bash
-set PUBLIC_API_SERVICE=http://localhost:8080
+export PUBLIC_API_SERVICE=http://localhost:8080
 ```
 
 First, you need to create a new account for a user:

--- a/scripts/start-local-env.sh
+++ b/scripts/start-local-env.sh
@@ -26,7 +26,7 @@ kubectl apply -f ./local/deployments/config-map.yaml --wait=true
 
 printf '\n📀 Deploy Redis\n\n'
 helm repo add bitnami https://charts.bitnami.com/bitnami
-helm install redis bitnami/redis
+helm install redis -n default --set architecture=standalone bitnami/redis
 
 printf '\n📀 Init Dapr\n\n'
 dapr init --kubernetes --wait --timeout 600

--- a/src/account-service/manifests/deployment.yaml
+++ b/src/account-service/manifests/deployment.yaml
@@ -32,3 +32,10 @@ spec:
             - name: AZURE_CLIENT_ID
               value: ${AZURE_AKS_IDENTITY_CLIENT_ID}
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "512m"
+              memory: "512Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"

--- a/src/account-service/src/main/java/com/azdaks/accountservice/config/AccountServiceConfiguration.java
+++ b/src/account-service/src/main/java/com/azdaks/accountservice/config/AccountServiceConfiguration.java
@@ -1,0 +1,15 @@
+package com.azdaks.accountservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.dapr.client.DaprClient;
+import io.dapr.client.DaprClientBuilder;
+
+@Configuration
+public class AccountServiceConfiguration {
+
+    @Bean
+    public DaprClient getDaprClient() {
+        return new DaprClientBuilder().build();
+    }
+}

--- a/src/account-service/src/main/java/com/azdaks/accountservice/controller/TransferEventController.java
+++ b/src/account-service/src/main/java/com/azdaks/accountservice/controller/TransferEventController.java
@@ -4,10 +4,6 @@ import io.dapr.Topic;
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.CloudEvent;
-import io.dapr.client.domain.GetStateRequest;
-import io.dapr.client.domain.State;
-import okhttp3.Request;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;

--- a/src/fraud-service/manifests/deployment.yaml
+++ b/src/fraud-service/manifests/deployment.yaml
@@ -32,3 +32,11 @@ spec:
         ports:
         - containerPort: 80
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: "512m"
+            memory: "512Mi"
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+            

--- a/src/fraud-service/src/main/java/com/azdaks/fraudservice/config/FraudServiceConfiguration.java
+++ b/src/fraud-service/src/main/java/com/azdaks/fraudservice/config/FraudServiceConfiguration.java
@@ -1,0 +1,15 @@
+package com.azdaks.fraudservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.dapr.client.DaprClient;
+import io.dapr.client.DaprClientBuilder;
+
+@Configuration
+public class FraudServiceConfiguration {
+
+    @Bean
+    public DaprClient getDaprClient() {
+        return new DaprClientBuilder().build();
+    }
+}

--- a/src/fraud-service/src/main/java/com/azdaks/fraudservice/controller/TransferEventController.java
+++ b/src/fraud-service/src/main/java/com/azdaks/fraudservice/controller/TransferEventController.java
@@ -4,11 +4,10 @@ import com.azdaks.fraudservice.model.StateRequest;
 import com.azdaks.fraudservice.model.TransferRequest;
 import io.dapr.Topic;
 import io.dapr.client.DaprClient;
-import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.CloudEvent;
-import io.dapr.client.domain.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,11 +25,13 @@ public class TransferEventController {
     private static final String STATE_TOPIC_NAME = "state";
     private static final String PUBLISHED_TOPIC_NAME = "validated";
 
-    private final DaprClient client = new DaprClientBuilder().build();
+    @Autowired
+    DaprClient client;
 
     @Topic(name = SUBSCRIBED_TOPIC_NAME, pubsubName = PUBSUB_NAME)
     @PostMapping(path = "/transfers", consumes = MediaType.ALL_VALUE)
-    public Mono<ResponseEntity> handleTransferRequest(@RequestBody(required = false) CloudEvent<TransferRequest> cloudEvent) {
+    public Mono<ResponseEntity> handleTransferRequest(
+            @RequestBody(required = false) CloudEvent<TransferRequest> cloudEvent) {
         return Mono.fromSupplier(() -> {
             try {
                 logger.info("Fraud service received: " + cloudEvent.getData().toString());

--- a/src/notification-service/manifests/deployment.yaml
+++ b/src/notification-service/manifests/deployment.yaml
@@ -32,3 +32,11 @@ spec:
         ports:
         - containerPort: 80
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: "512m"
+            memory: "512Mi"
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+            

--- a/src/notification-service/src/main/java/com/azdaks/notificationservice/config/AccountServiceConfiguration.java
+++ b/src/notification-service/src/main/java/com/azdaks/notificationservice/config/AccountServiceConfiguration.java
@@ -1,0 +1,15 @@
+package com.azdaks.notificationservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.dapr.client.DaprClient;
+import io.dapr.client.DaprClientBuilder;
+
+@Configuration
+public class AccountServiceConfiguration {
+
+    @Bean
+    public DaprClient getDaprClient() {
+        return new DaprClientBuilder().build();
+    }
+}

--- a/src/notification-service/src/main/java/com/azdaks/notificationservice/controller/TransferEventController.java
+++ b/src/notification-service/src/main/java/com/azdaks/notificationservice/controller/TransferEventController.java
@@ -2,14 +2,10 @@ package com.azdaks.notificationservice.controller;
 
 import io.dapr.Topic;
 import io.dapr.client.DaprClient;
-import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.CloudEvent;
-import io.dapr.client.domain.GetStateRequest;
-import io.dapr.client.domain.State;
-import okhttp3.Request;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,11 +26,13 @@ public class TransferEventController {
     private static final String TRANSFER_SUBSCRIBED_TOPIC_NAME = "approved";
     private static final String STATE_TOPIC_NAME = "state";
 
-    private final DaprClient client = new DaprClientBuilder().build();
+    @Autowired
+    DaprClient client;
 
     @Topic(name = TRANSFER_SUBSCRIBED_TOPIC_NAME, pubsubName = PUBSUB_NAME)
     @PostMapping(path = "/transfers", consumes = MediaType.ALL_VALUE)
-    public Mono<ResponseEntity> handleTransferRequest(@RequestBody(required = false) CloudEvent<TransferRequest> cloudEvent) {
+    public Mono<ResponseEntity> handleTransferRequest(
+            @RequestBody(required = false) CloudEvent<TransferRequest> cloudEvent) {
         return Mono.fromSupplier(() -> {
             try {
                 logger.info("Notification service transfer request received: " + cloudEvent.getData().toString());
@@ -48,7 +46,6 @@ public class TransferEventController {
 
                 logger.info("Publishing state request: " + stateRequest);
                 publishStateRequest(stateRequest, "COMPLETED");
-                
 
                 return ResponseEntity.ok("SUCCESS");
 

--- a/src/public-api-service/manifests/deployment.yaml
+++ b/src/public-api-service/manifests/deployment.yaml
@@ -32,3 +32,10 @@ spec:
         ports:
         - containerPort: 80
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: "512m"
+            memory: "512Mi"
+          requests:
+            cpu: "100m"
+            memory: "128Mi"

--- a/src/public-api-service/src/main/java/com/azdaks/publicapiservice/PublicApiServiceApplication.java
+++ b/src/public-api-service/src/main/java/com/azdaks/publicapiservice/PublicApiServiceApplication.java
@@ -1,6 +1,5 @@
 package com.azdaks.publicapiservice;
 
-import com.azdaks.publicapiservice.controller.TransfersController;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/src/public-api-service/src/main/java/com/azdaks/publicapiservice/config/AccountServiceConfiguration.java
+++ b/src/public-api-service/src/main/java/com/azdaks/publicapiservice/config/AccountServiceConfiguration.java
@@ -1,0 +1,23 @@
+package com.azdaks.publicapiservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.dapr.client.DaprClient;
+import io.dapr.client.DaprClientBuilder;
+
+@Configuration
+public class AccountServiceConfiguration {
+
+    @Bean
+    public DaprClient getDaprClient() {
+        return new DaprClientBuilder().build();
+    }
+
+    @Bean
+    public ObjectMapper getObjectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/public-api-service/src/main/java/com/azdaks/publicapiservice/controller/StatesController.java
+++ b/src/public-api-service/src/main/java/com/azdaks/publicapiservice/controller/StatesController.java
@@ -1,15 +1,14 @@
 package com.azdaks.publicapiservice.controller;
 
-
 import com.azdaks.publicapiservice.model.MoneyTransfer;
 import com.azdaks.publicapiservice.model.StateRequest;
 import io.dapr.Topic;
 import io.dapr.client.DaprClient;
-import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.CloudEvent;
 import io.dapr.client.domain.State;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,7 +25,8 @@ public class StatesController {
 
     private static final Logger logger = LoggerFactory.getLogger(TransfersController.class.getName());
 
-    private final DaprClient client = new DaprClientBuilder().build();
+    @Autowired
+    DaprClient client;
 
     @Topic(name = SUBSCRIBED_TOPIC_NAME, pubsubName = PUBSUB_NAME)
     @PostMapping(path = "/states", consumes = MediaType.ALL_VALUE)
@@ -37,7 +37,8 @@ public class StatesController {
                 var stateRequest = cloudEvent.getData();
 
                 logger.info("Getting state from state store: " + stateRequest.getTransferId());
-                State<MoneyTransfer> moneyTransferState = client.getState(STATE_STORE, stateRequest.getTransferId(), MoneyTransfer.class).block();
+                State<MoneyTransfer> moneyTransferState = client
+                        .getState(STATE_STORE, stateRequest.getTransferId(), MoneyTransfer.class).block();
                 var moneyTransfer = moneyTransferState.getValue();
                 moneyTransfer.setStatus(stateRequest.getStatus());
 


### PR DESCRIPTION
- Updated README to clarify some setup instructions to make it easier to get it working locally.
- Changed Redis deployment to KIND cluster to be standalone (we don't really need 3 replicas locally)
- Added Autowired and dependency injection Beans for DaprClient and ObjectMapper.
- Added resource limits to all AKS deployments to prevent OOMs.
- Tested locally 