### PR TITLE
Autowiring Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ First, you need to create a new account for a user:
 
 ```curl
 curl -X POST \
-  http://localhost:8080/accounts \
+  $PUBLIC_API_SERVICE/accounts \
   -H 'Content-Type: application/json' \
   -d '{
     "owner": "A",
@@ -264,7 +264,7 @@ An example request to start a new transfer workflow is:
 
 ```curl
 curl -X POST \
-  http://localhost:8080/transfers \
+  $PUBLIC_API_SERVICE/transfers \
   -H 'Content-Type: application/json' \
   -d '{
     "sender": "A",
@@ -287,7 +287,7 @@ You can query the status of a transfer:
 
 ```curl
 curl -X GET \
-  http://localhost:8080/transfers/{transferId} \
+  $PUBLIC_API_SERVICE/transfers/{transferId} \
   -H 'Content-Type: application/json'
 ```
 

--- a/src/account-service/src/main/java/com/azdaks/accountservice/controller/TransferEventController.java
+++ b/src/account-service/src/main/java/com/azdaks/accountservice/controller/TransferEventController.java
@@ -6,6 +6,7 @@ import io.dapr.client.DaprClientBuilder;
 import io.dapr.client.domain.CloudEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,7 +31,8 @@ public class TransferEventController {
     private static final String STATE_STORE = "money-transfer-state";
     private static final String ACCOUNT_UPDATE_TOPIC = "account-update";
 
-    private final DaprClient client = new DaprClientBuilder().build();
+    @Autowired
+    DaprClient client;
 
     @Topic(name = TRANSFER_SUBSCRIBED_TOPIC_NAME, pubsubName = PUBSUB_NAME)
     @PostMapping(path = "/transfers", consumes = MediaType.ALL_VALUE)

--- a/src/public-api-service/src/main/java/com/azdaks/publicapiservice/config/AccountServiceConfiguration.java
+++ b/src/public-api-service/src/main/java/com/azdaks/publicapiservice/config/AccountServiceConfiguration.java
@@ -3,7 +3,9 @@ package com.azdaks.publicapiservice.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
@@ -18,6 +20,12 @@ public class AccountServiceConfiguration {
 
     @Bean
     public ObjectMapper getObjectMapper() {
-        return new ObjectMapper();
+        /**
+         * This object mapper instance overrides the shared instance in CloudEvent class
+         * To avoid serialization issues with the CloudEvent class, we need to apply their ObjectMapper configuration
+         */
+        return new ObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 }

--- a/src/public-api-service/src/main/java/com/azdaks/publicapiservice/controller/AccountsController.java
+++ b/src/public-api-service/src/main/java/com/azdaks/publicapiservice/controller/AccountsController.java
@@ -28,7 +28,7 @@ public class AccountsController {
     private static final String TOPIC_NAME = "deposit";
     private static final String ACCOUNT_UPDATE_TOPIC = "account-update";
 
-    private static final Logger logger = LoggerFactory.getLogger(TransfersController.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(AccountsController.class.getName());
 
     @Autowired
     DaprClient client;

--- a/src/public-api-service/src/main/java/com/azdaks/publicapiservice/controller/StatesController.java
+++ b/src/public-api-service/src/main/java/com/azdaks/publicapiservice/controller/StatesController.java
@@ -23,7 +23,7 @@ public class StatesController {
     private static final String SUBSCRIBED_TOPIC_NAME = "state";
     private static final String STATE_STORE = "money-transfer-state";
 
-    private static final Logger logger = LoggerFactory.getLogger(TransfersController.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(StatesController.class.getName());
 
     @Autowired
     DaprClient client;


### PR DESCRIPTION
As PR #13  introduced `@Autowiring`, the `ObjectMapper` instance created and automatically injected clashed with `ObjectMapper` in `CloudEvent`.

https://dapr.github.io/java-sdk/io/dapr/client/domain/CloudEvent.html

**Theory**
Because `ObjectMapper` in `CloudEvent` created as `static`, Autowiring replaces it with reflection in their implementation:

**Fix**
Adding `ObjectMapper` configuration of `CloudEvent` to Autowiring fixed the issue. 

Tests were failing in CI too. Now they are all green :)