### PR TITLE
Removing namespace dependency from redis deployment

### DIFF
--- a/infra/redis.yaml
+++ b/infra/redis.yaml
@@ -540,7 +540,7 @@ spec:
             - name: REDIS_REPLICATION_MODE
               value: replica
             - name: REDIS_MASTER_HOST
-              value: redis-master-0.redis-headless.${DAPR_NAMESPACE}.svc.cluster.local
+              value: redis-master-0.redis-headless.${AZURE_ENV_NAME}.svc.cluster.local
             - name: REDIS_MASTER_PORT_NUMBER
               value: "6379"
             - name: ALLOW_EMPTY_PASSWORD

--- a/infra/redis.yaml
+++ b/infra/redis.yaml
@@ -5,7 +5,6 @@ kind: ServiceAccount
 automountServiceAccountToken: true
 metadata:
   name: redis
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -17,7 +16,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: redis
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -32,7 +30,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: redis-configuration
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -64,7 +61,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: redis-health
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -171,7 +167,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: redis-scripts
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -251,7 +246,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-headless
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -275,7 +269,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-master
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -301,7 +294,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis-replicas
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -327,7 +319,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-master
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -482,7 +473,6 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: redis-replicas
-  namespace: "java-banking-pubsub-dapr-sample"
   labels:
     app.kubernetes.io/name: redis
     helm.sh/chart: redis-17.10.3
@@ -550,7 +540,7 @@ spec:
             - name: REDIS_REPLICATION_MODE
               value: replica
             - name: REDIS_MASTER_HOST
-              value: redis-master-0.redis-headless.java-banking-pubsub-dapr-sample.svc.cluster.local
+              value: redis-master-0.redis-headless.${DAPR_NAMESPACE}.svc.cluster.local
             - name: REDIS_MASTER_PORT_NUMBER
               value: "6379"
             - name: ALLOW_EMPTY_PASSWORD


### PR DESCRIPTION
hardcoded namespace in Redis deployment prevents `azd up` from a fresh repository to run properly when using a different `env name`

With this change Redis will inherit namespace specification via the deployment command `kubectl apply <...> --namespace $AZURE_ENV_NAME`